### PR TITLE
Avoid import problems in setup.py

### DIFF
--- a/fatzebra/gateway.py
+++ b/fatzebra/gateway.py
@@ -147,6 +147,8 @@ class Gateway(object):
             headers=self._headers()
         )
         if response.status_code == 201 or response.status_code == 200:
+            if callable(response.json): # newer versions of requests
+                return response.json()
             return response.json
         else:
             if response.status_code == 401:

--- a/fatzebra/version.py
+++ b/fatzebra/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.5"
+VERSION = "0.0.5" # edit with care, see setup.py

--- a/fatzebra/version.py
+++ b/fatzebra/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.5" # edit with care, see setup.py
+VERSION = "0.0.6" # edit with care, see setup.py

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
-# Don't import fatzebra module here, since deps may not be installed
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'fatzebra'))
-from fatzebra import version
-
-path, script = os.path.split(sys.argv[0])
-os.chdir(os.path.abspath(path))
-
 setup(name='fatzebra',
-    version=version.VERSION,
+    version=open('fatzebra/version.py').read().split('"')[1],
     description='Fat Zebra Python Library',
     long_description=open("README.txt").read(),
     author='Fat Zebra',


### PR DESCRIPTION
- even in the `fatzebra.version` submodule, `VERSION` could not be imported because `fatzebra.__init__` imports `gateway`
- this is a little hackish, but is a quick/compatible fix for now
